### PR TITLE
bugfix:css build된 것 뺌

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+/src/sass/tailwind.output.css


### PR DESCRIPTION
css build된거 뺐습니다.

이제 npm run build:tailwind를 하시면 됩니다.

뺀 이유는 github에 css가 90%넘게 차지하고 있어서 뺐습니다.
